### PR TITLE
Allow banning people who are not in the group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+configuration.lua

--- a/languages/de_de.lua
+++ b/languages/de_de.lua
@@ -48,8 +48,6 @@ return {
     ['ban'] = {
         ['1'] = 'Welchen Benutzer soll ich sperren? Du kannst den Benutzer mit dem Benutzernamen oder mit der Identifikationsnummer angeben.',
         ['2'] = 'Ich kann diesen Benutzer nicht sperren, weil er/sie ein Moderator oder Administrator in dieser Gruppe ist.',
-        ['3'] = 'Ich kann diesen Benutzer nicht sperren, weil er/sie die Gruppe schon verlassen hat.',
-        ['4'] = 'Ich kann diesen Benutzer nicht sperren, weil er/sie für die Gruppe schon gesperrt ist.',
         ['5'] = 'Ich muss Administrationsberechtigung haben damit ich den Benutzer sperren kann. Bitte kümmer dich um das Problem und versuche es noch einmal.'
     },
     ['bash'] = {

--- a/languages/en_gb.lua
+++ b/languages/en_gb.lua
@@ -48,8 +48,6 @@ return {
     ['ban'] = {
         ['1'] = 'Which user would you like me to ban? You can specify this user by their @username or numerical ID.',
         ['2'] = 'I cannot ban this user because they are a moderator or an administrator in this chat.',
-        ['3'] = 'I cannot ban this user because they have already left this chat.',
-        ['4'] = 'I cannot ban this user because they have already been banned from this chat.',
         ['5'] = 'I need to have administrative permissions in order to ban this user. Please amend this issue, and try again.'
     },
     ['bash'] = {

--- a/languages/en_us.lua
+++ b/languages/en_us.lua
@@ -48,8 +48,6 @@ return {
     ['ban'] = {
         ['1'] = 'Which user would you like me to ban? You can specify this user by their @username or numerical ID.',
         ['2'] = 'I cannot ban this user because they are a moderator or an administrator in this chat.',
-        ['3'] = 'I cannot ban this user because they have already left this chat.',
-        ['4'] = 'I cannot ban this user because they have already been banned from this chat.',
         ['5'] = 'I need to have administrative permissions in order to ban this user. Please amend this issue, and try again.'
     },
     ['bash'] = {

--- a/languages/pl_pl.lua
+++ b/languages/pl_pl.lua
@@ -48,8 +48,6 @@ return {
     ['ban'] = {
         ['1'] = 'Kogo mam zbanować? Podaj @username lub ID.',
         ['2'] = 'Nie mogę zbanować tego użytkownika, ponieważ jest to moderator lub administrator tej grupy.',
-        ['3'] = 'Nie mogę zbanować tego użytkownika, ponieważ opuścił on tę grupę.',
-        ['4'] = 'Nie mogę zbanować tego użytkownika, ponieważ został on zbanowany już wcześniej.',
         ['5'] = 'Potrzebuję uprawnień administratora aby móc banować.'
     },
     ['bash'] = {

--- a/languages/pt_pt.lua
+++ b/languages/pt_pt.lua
@@ -48,8 +48,6 @@ return {
     ['ban'] = {
         ['1'] = 'Qual utilizador gostaria que eu bane? Pode especificar esse utilizador pelo seu @username ou ID numérico.',
         ['2'] = 'Não consigo banir esse utilizador porque ele é um moderador ou um administrador neste grupo.',
-        ['3'] = 'Não consigo banir este utilizador porque ele saiu deste grupo.',
-        ['4'] = 'Não consigo banir este utilizador porque ele já foi banido deste grupo.',
         ['5'] = 'Eu preciso ter permissões administrativas para banir esse utilizador. Corrija este problema e tente novamente.'
     },
     ['bash'] = {

--- a/languages/scottish.lua
+++ b/languages/scottish.lua
@@ -48,8 +48,6 @@ return {
     ['ban'] = {
         ['1'] = 'Which usar wud ye like me tae ban? Ye can specify thes usar by thair @usarname ore numerical ID.',
         ['2'] = 'A cannae ban thes usar becawis thei be a moderator ore an administrator in thes tauk.',
-        ['3'] = 'A cannae ban thes usar becawis thei have alrady left thes tauk.',
-        ['4'] = 'A cannae ban thes usar becawis thei have alrady been banned from thes tauk.',
         ['5'] = 'A need tae have administrative permissions in maun tae ban thes usar. Pleese mend thes issue, and pree again.'
     },
     ['bash'] = {

--- a/languages/tr_tr.lua
+++ b/languages/tr_tr.lua
@@ -48,8 +48,6 @@ return {
     ['ban'] = {
         ['1'] = 'Hangi kullanıcı banlamamı istersiniz? Bu kullanıcıyı @kulanıcıadı şeklinde veya kullanıcı IDsi ile belirtebilirsin.',
         ['2'] = 'Bu kullanıcıyı, bu sohbette bir moderatör veya yönetici oldukları için banlayamam.',
-        ['3'] = 'Bu sohbetten ayrıldığı için bu kullanıcıyı banyalamam.',
-        ['4'] = 'Bu sohbetten zaten banlandıkları için bu kullanıcıyı yasaklayamam.',
         ['5'] = 'Bu kullanıcıyı banlamam için admin izinlerine sahip olmam gerekiyor. Lütfen bu sorunu düzeltip tekrar deneyin.'
     },
     ['bash'] = {

--- a/plugins/ban.lua
+++ b/plugins/ban.lua
@@ -117,15 +117,6 @@ function ban:on_message(message, configuration, language)
             message,
             language['ban']['2']
         )
-    elseif status.result.status == 'left'
-    or status.result.status == 'kicked'
-    then -- Check if the user is in the group or not.
-        return mattata.send_reply(
-            message,
-            status.result.status == 'left'
-            and language['ban']['3']
-            or language['ban']['4']
-        )
     end
     local success = mattata.ban_chat_member( -- Attempt to ban the user from the group.
         message.chat.id,


### PR DESCRIPTION
When people who are not in the group get banned, they can't join.

Removed strings which were rendered unused by the change.


Also, added `configuration.lua` (not `configuration.example.lua`) to `.gitignore`.


Offtopic:
1. My editor claims that ban plugin somehow has WIndows style line endings.
2. Please create, test and commit a Vagrantfile or Dockerfile, so it's easier to set up development environment.