### PR TITLE
[WIP] Mute using restrict_chat_member

### DIFF
--- a/mattata.lua
+++ b/mattata.lua
@@ -2633,18 +2633,7 @@ function mattata.process_stickers(message)
 end
 
 function mattata.process_spam(message)
-    if redis:sismember(
-        'chat:' .. message.chat.id .. ':muted_users',
-        tostring(message.from.id)
-    )
-    then
-        print('Message deleted from ' .. message.from.id .. ' in ' .. message.chat.id)
-        mattata.delete_message(
-            message.chat.id,
-            message.message_id
-        )
-        return true
-    elseif message.chat
+    if message.chat
     and message.chat.title
     and message.chat.title:match('[Pp][Oo][Nn][Zz][Ii]')
     and message.chat.type ~= 'private'

--- a/plugins/mute.lua
+++ b/plugins/mute.lua
@@ -106,10 +106,7 @@ function mute:on_message(message, configuration, language)
             message,
             language['errors']['generic']
         )
-    elseif redis:sismember(
-        'chats:' .. message.chat.id .. ':muted_users',
-        user_object.id
-    )
+    elseif status.result.can_send_messages == false
     then -- The user is already muted.
         return mattata.send_reply(
             message,
@@ -145,10 +142,7 @@ function mute:on_message(message, configuration, language)
             language['mute']['5']
         )
     end
-    redis:sadd(
-        'chat:' .. message.chat.id .. ':muted_users',
-        user_object.id
-    )
+    mattata.restrict_chat_member(message.chat.id, user_object.id, nil, false)
     redis:hincrby(
         string.format(
             'chat:%s:%s',

--- a/plugins/unmute.lua
+++ b/plugins/unmute.lua
@@ -106,10 +106,7 @@ function unmute:on_message(message, configuration, language)
             message,
             language['errors']['generic']
         )
-    elseif redis:sismember(
-        'chats:' .. message.chat.id .. ':muted_users',
-        user_object.id
-    )
+    elseif status.result.status ~= 'restricted'
     then -- The user isn't currently muted.
         return mattata.send_reply(
             message,
@@ -134,10 +131,7 @@ function unmute:on_message(message, configuration, language)
             language['unmute']['4']
         )
     end
-    redis:srem(
-        'chat:' .. message.chat.id .. ':muted_users',
-        user_object.id
-    )
+    mattata.restrict_chat_member(message.chat.id, user_object.id, nil, true, true, true)
     redis:hincrby(
         string.format(
             'chat:%s:%s',


### PR DESCRIPTION
**THIS IS WORK IN PROGRESS**

Use restrict_chat_member instead of deleting messages from muted users.

Why work in progress?
Unmute doesn't work properly yet.
It doesn't currently remove can_add_web_page_previews restriction.
When trying to do that, Telegram API replies `{ ok: true, result: true }`,
but removes no restricions. I couldn't find why.

I also couldn't reproduce with @TheEngineBot's /unmute,
so I suspect this is a problem with telegram-bot-lua.

**THIS IS WORK IN PROGRESS**