### PR TITLE
Fix Connection Error

### DIFF
--- a/plugins/currency.lua
+++ b/plugins/currency.lua
@@ -39,7 +39,7 @@ function currency:on_message(message, configuration, language)
     amount = tonumber(amount)
     or 1
     local result = 1
-    local url = 'https://www.google.com/finance/converter'
+    local url = 'https://finance.google.com/finance/converter'
     if from ~= to
     then
         local str, res = https.request(


### PR DESCRIPTION
Google has moved `https://www.google.com/finance/converter` to `https://finance.google.com/finance/converter`, it causes a `connection error` exception.